### PR TITLE
Ajusta cor do header conforme fundo da seção

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -253,16 +253,21 @@ h1, h2, h3, h4, h5, h6 {
     font-weight: 500;
     transition: var(--transition);
 }
-.header-scrolled .nav-link {
-    color: var(--primary-light);
-}
-
 .nav-link:hover {
     color: var(--primary-light);
 }
 
-.header-scrolled .nav-link:hover {
+/* Header color variants for contrast */
+.header-light .nav-link {
+    color: var(--primary-light);
+}
+
+.header-light .nav-link:hover {
     color: var(--primary-dark);
+}
+
+.header-dark .nav-link {
+    color: var(--white);
 }
 
 /* Active navigation link */

--- a/js/script.js
+++ b/js/script.js
@@ -110,24 +110,53 @@ document.addEventListener('DOMContentLoaded', function() {
     // Header scroll effect
     const header = document.querySelector('.header');
     let lastScrollTop = 0;
-    
+
+    const darkSections = document.querySelectorAll('.hero-home, .services-hero, .cases-hero, .about-hero, .final-cta');
+
+    function updateHeaderColor() {
+        const headerHeight = header.offsetHeight;
+        const scrollPos = window.scrollY + headerHeight;
+        let inDarkSection = false;
+
+        darkSections.forEach(section => {
+            const rect = section.getBoundingClientRect();
+            const sectionTop = rect.top + window.scrollY;
+            const sectionBottom = sectionTop + rect.height;
+            if (scrollPos >= sectionTop && scrollPos <= sectionBottom) {
+                inDarkSection = true;
+            }
+        });
+
+        if (inDarkSection) {
+            header.classList.add('header-dark');
+            header.classList.remove('header-light');
+        } else {
+            header.classList.add('header-light');
+            header.classList.remove('header-dark');
+        }
+    }
+
     window.addEventListener('scroll', function() {
         const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        
+
         if (scrollTop > 100) {
             header.classList.add('header-scrolled');
         } else {
             header.classList.remove('header-scrolled');
         }
-        
+
+        updateHeaderColor();
+
         // Ensure floating button remains visible
         if (floatingContactElement) {
             floatingContactElement.style.opacity = '1';
             floatingContactElement.style.visibility = 'visible';
         }
-        
+
         lastScrollTop = scrollTop;
     });
+
+    updateHeaderColor();
     
     // Intersection Observer for animations
     const observerOptions = {


### PR DESCRIPTION
## Sumário
- ajusta estilos do header para alternar entre texto roxo e branco
- adiciona script para detectar seções com fundo escuro e trocar a cor do header automaticamente

## Testes
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689795ae9d2c832d92ba34221c1b7e0e