### PR TITLE
Fix testimonials navigation arrows

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -570,7 +570,6 @@ window.LabregoIA = {
     showFormMessage
 };
 
-<script>
 (function(){
   const root = document.querySelector('.bh-carousel');
   if(!root) return;
@@ -657,7 +656,6 @@ window.LabregoIA = {
 
   layout();
 })();
-</script>
 
 // Troca cor do header conforme você sai do HERO (fundo escuro) para as seções claras
 (function () {


### PR DESCRIPTION
## Summary
- remove stray HTML script tags from main JS file so subsequent code executes
- restore testimonial carousel navigation behavior

## Testing
- `node --check js/script.js`
- `node - <<'NODE'
const fs=require('fs');const path=require('path');const {JSDOM}=require('jsdom');let html=fs.readFileSync('index.html','utf8');html=html.replace(/<link[^>]+https?:\/\/[^>]+>/g,'').replace(/<script[^>]+https?:\/\/[^>]+><\/script>/g,'');const dom=new JSDOM(html,{runScripts:"dangerously",resources:"usable",url:'file://'+path.resolve('index.html')});dom.window.addEventListener('load',()=>{const slides=dom.window.document.querySelectorAll('.testimonial-slide');const nextBtn=dom.window.document.getElementById('nextTestimonial');console.log('slides length',slides.length);console.log('initial active',Array.from(slides).findIndex(el=>el.classList.contains('active')));nextBtn.dispatchEvent(new dom.window.MouseEvent('click',{bubbles:true}));console.log('after click active',Array.from(slides).findIndex(el=>el.classList.contains('active')));dom.window.close();});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b8b3b09b20832da2aaeea347cbe555