### PR TITLE
Fix stray CSS marker comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
       "https://www.youtube.com/@labregoia"
     ]
   }
-  </script>-- seu CSS principal -->
+  </script>
+  <!-- seu CSS principal -->
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- Prevent "seu CSS principal" text from appearing by properly commenting the CSS marker in `index.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b4e30a94832d8c0ef4a3df482054