### PR TITLE
Add Meta webhook proxy endpoint

### DIFF
--- a/api/meta/webhooks.js
+++ b/api/meta/webhooks.js
@@ -1,0 +1,37 @@
+const VERIFY_TOKEN = process.env.META_VERIFY_TOKEN;
+const CRM_ENDPOINT = process.env.CRM_ENDPOINT;
+
+module.exports = async (req, res) => {
+  if (req.method === 'GET') {
+    const mode = req.query['hub.mode'];
+    const token = req.query['hub.verify_token'];
+    const challenge = req.query['hub.challenge'];
+
+    if (mode === 'subscribe' && token === VERIFY_TOKEN) {
+      res.status(200).send(challenge);
+    } else {
+      res.status(403).send('Forbidden');
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    try {
+      if (CRM_ENDPOINT) {
+        await fetch(CRM_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(req.body)
+        });
+      }
+      res.status(200).json({ status: 'ok' });
+    } catch (error) {
+      console.error('Webhook forwarding error:', error);
+      res.status(500).json({ error: 'Failed to forward webhook' });
+    }
+    return;
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).end('Method Not Allowed');
+};

--- a/vercel.json
+++ b/vercel.json
@@ -26,5 +26,10 @@
         { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" }
       ]
     }
-  ]
+  ],
+  "functions": {
+    "api/**.js": {
+      "runtime": "nodejs18.x"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add serverless function to forward Meta-style webhook payloads to a CRM endpoint
- configure Vercel functions to use Node.js 18 runtime

## Testing
- `node -e "require('./api/meta/webhooks.js'); console.log('loaded');"`
- `node <<'NODE'
const handler = require('./api/meta/webhooks.js');
const req = { method: 'POST', body: { hello: 'world' } };
const res = { status(code){ console.log('status', code); return this; }, json(obj){ console.log('json', obj); }, setHeader(){}, end(msg){ console.log('end', msg); }, send(msg){ console.log('send', msg); } };
handler(req, res).then(()=> console.log('done'));
NODE`
- `node <<'NODE'
process.env.META_VERIFY_TOKEN = 'token';
const handler = require('./api/meta/webhooks.js');
const req = { method: 'GET', query: { 'hub.mode': 'subscribe', 'hub.verify_token': 'token', 'hub.challenge': '123' } };
const res = { status(code){ console.log('status', code); return this; }, send(msg){ console.log('send', msg); }, setHeader(){}, end(msg){ console.log('end', msg); } };
handler(req, res).then(()=> console.log('done'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b8beb6bf48832d9452e18ee7f08850