### PR TITLE
Specify Vercel Node runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,7 +29,7 @@
   ],
   "functions": {
     "api/**.js": {
-      "runtime": "nodejs18.x"
+      "runtime": "@vercel/node@5.3.20"
     }
   }
 }


### PR DESCRIPTION
## Summary
- define `@vercel/node@5.3.20` runtime for serverless functions

## Testing
- `npx vercel build --yes` *(fails: The specified token is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c1d0e7f4832d892d5e727b817716