### PR TITLE
Fix Vercel config for static build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,9 +27,5 @@
       ]
     }
   ],
-  "functions": {
-    "api/**.js": {
-      "runtime": "@vercel/node@5.3.20"
-    }
-  }
+  "functions": {}
 }


### PR DESCRIPTION
## Summary
- prevent Vercel build failure by clearing unmatched `api/**.js` function pattern

## Testing
- `npm test` *(fails: enoent could not read package.json)*
- `npx vercel build` *(fails: interactive authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c3205a98832d8b6d44fb8beacc40