### PR TITLE
Fix Vercel config for nested API routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
     }
   ],
   "functions": {
-    "api/**.js": {
+    "api/**/*.js": {
       "runtime": "@vercel/node@5.3.20"
     }
   }


### PR DESCRIPTION
## Summary
- restore Vercel function runtime config using correct `api/**/*.js` glob

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx vercel build` *(fails: required interactive authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c3205a98832d8b6d44fb8beacc40