### PR TITLE
Send contact form submissions via email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/api/contact.js
+++ b/api/contact.js
@@ -1,0 +1,34 @@
+const nodemailer = require('nodemailer');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { name, email, phone, company, service, message } = req.body || {};
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to: 'contato@labregoia.com.br',
+      subject: 'Novo contato do site',
+      text: `Nome: ${name}\nEmail: ${email}\nTelefone: ${phone}\nEmpresa: ${company}\nServiço: ${service}\nMensagem: ${message}`
+    });
+
+    res.status(200).json({ status: 'ok' });
+  } catch (error) {
+    console.error('Email send error:', error);
+    res.status(500).json({ error: 'Failed to send email' });
+  }
+};

--- a/js/script.js
+++ b/js/script.js
@@ -61,25 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
             submitBtn.innerHTML = 'Enviando...';
             
             // Send form data to backend endpoint
-            const payload = {
-                entry: [{
-                    changes: [{
-                        field: 'leadgen',
-                        value: {
-                            leadgen_id: `contact_form_${Date.now()}`,
-                            page_id: 'website',
-                            form_id: 'contact',
-                            created_time: new Date().toISOString(),
-                            contact: data
-                        }
-                    }]
-                }]
-            };
-
-            fetch('/api/meta/webhooks', {
+            fetch('/api/contact', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
+                body: JSON.stringify(data)
             })
             .then(response => {
                 if (!response.ok) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "labregoia-site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "labregoia-site",
+      "version": "1.0.0",
+      "dependencies": {
+        "nodemailer": "^6.9.5"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "labregoia-site",
+  "version": "1.0.0",
+  "dependencies": {
+    "nodemailer": "^6.9.5"
+  }
+}


### PR DESCRIPTION
## Summary
- send contact form data to a new `/api/contact` endpoint that emails contato@labregoia.com.br
- add nodemailer dependency and ignore `node_modules`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b99420d694832da23b436b18e7db8b