### PR TITLE
feat: configure smtp for contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=usuario@example.com
+SMTP_PASS=senha
+SMTP_FROM=no-reply@example.com

--- a/INSTRUCOES_HOSPEDAGEM.md
+++ b/INSTRUCOES_HOSPEDAGEM.md
@@ -125,6 +125,18 @@ Configure emails como `contato@seudominio.com`:
 2. Crie contas de email
 3. Configure no cliente de email
 
+### Formulário de Contato
+Para que o formulário de contato envie mensagens por email é necessário configurar um serviço SMTP. Crie um arquivo `.env` com as seguintes variáveis (veja `.env.example`):
+```
+SMTP_HOST=seu_servidor
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=seu_usuario
+SMTP_PASS=sua_senha
+SMTP_FROM=no-reply@seudominio.com
+```
+Em produção, defina essas variáveis no painel de hospedagem ou na plataforma (por exemplo, Vercel) que executará a função em `api/contact.js`.
+
 ### Backup
 Configure backup automático:
 1. Vá em **Backup** no hPanel

--- a/api/contact.js
+++ b/api/contact.js
@@ -1,4 +1,5 @@
 const nodemailer = require('nodemailer');
+require('dotenv').config();
 
 module.exports = async (req, res) => {
   if (req.method !== 'POST') {
@@ -8,19 +9,25 @@ module.exports = async (req, res) => {
 
   const { name, email, phone, company, service, message } = req.body || {};
 
+  const { SMTP_HOST, SMTP_PORT, SMTP_SECURE, SMTP_USER, SMTP_PASS, SMTP_FROM } = process.env;
+  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS) {
+    console.error('Missing SMTP configuration');
+    return res.status(500).json({ error: 'Email service not configured' });
+  }
+
   const transporter = nodemailer.createTransport({
-    host: process.env.SMTP_HOST,
-    port: parseInt(process.env.SMTP_PORT || '587', 10),
-    secure: process.env.SMTP_SECURE === 'true',
+    host: SMTP_HOST,
+    port: parseInt(SMTP_PORT || '587', 10),
+    secure: SMTP_SECURE === 'true',
     auth: {
-      user: process.env.SMTP_USER,
-      pass: process.env.SMTP_PASS
+      user: SMTP_USER,
+      pass: SMTP_PASS
     }
   });
 
   try {
     await transporter.sendMail({
-      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      from: SMTP_FROM || SMTP_USER,
       to: 'contato@labregoia.com.br',
       subject: 'Novo contato do site',
       text: `Nome: ${name}\nEmail: ${email}\nTelefone: ${phone}\nEmpresa: ${company}\nServiço: ${service}\nMensagem: ${message}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,20 @@
       "name": "labregoia-site",
       "version": "1.0.0",
       "dependencies": {
+        "dotenv": "^16.3.1",
         "nodemailer": "^6.9.5"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/nodemailer": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "labregoia-site",
   "version": "1.0.0",
   "dependencies": {
+    "dotenv": "^16.3.1",
     "nodemailer": "^6.9.5"
   }
 }


### PR DESCRIPTION
## Summary
- load smtp settings from environment variables for contact form
- provide .env example and hosting instructions

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bad8ce60dc832d8f7fbe7e19524049