### PR TITLE
Exibe pop-up personalizado após envio do formulário

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3721,6 +3721,48 @@ html {
     color: var(--primary-color);
 }
 
+/* Contact success modal */
+.contact-success-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 1100;
+    padding: 20px;
+}
+
+.contact-success-modal.open {
+    display: flex;
+}
+
+.contact-success-modal__content {
+    background: var(--white);
+    padding: 40px;
+    border-radius: var(--border-radius-lg);
+    text-align: center;
+    max-width: 400px;
+    width: 100%;
+    position: relative;
+    box-shadow: var(--shadow-lg);
+}
+
+.contact-success-modal__close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: var(--text-muted);
+}
+
+.contact-success-modal__close:hover {
+    color: var(--primary-color);
+}
+
 .service-details ul {
     margin-top: 16px;
     padding-left: 20px;

--- a/index.html
+++ b/index.html
@@ -799,6 +799,15 @@
     </button>
   </div>
 
+  <!-- Success Modal -->
+  <div class="contact-success-modal" id="successModal" aria-hidden="true">
+    <div class="contact-success-modal__content">
+      <button class="contact-success-modal__close" id="successModalClose" aria-label="Fechar">&times;</button>
+      <h2 class="contact-success-modal__title" id="successModalTitle"></h2>
+      <p class="contact-success-modal__message" id="successModalMessage"></p>
+    </div>
+  </div>
+
   <!-- Seus scripts existentes -->
   <script src="js/script.js"></script>
   <script src="js/cases-vitrine.js" defer></script>

--- a/js/script.js
+++ b/js/script.js
@@ -31,6 +31,14 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
+    // Success modal for contact form
+    const successModal = document.getElementById('successModal');
+    const successModalClose = document.getElementById('successModalClose');
+    successModalClose?.addEventListener('click', () => successModal.classList.remove('open'));
+    successModal?.addEventListener('click', (e) => {
+        if (e.target === successModal) successModal.classList.remove('open');
+    });
+
     // Contact form submission
     document.getElementById('contactForm')?.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -55,7 +63,14 @@ document.addEventListener('DOMContentLoaded', function() {
             const body = await res.json().catch(() => ({}));
             if (!res.ok) throw new Error(body?.error || `HTTP ${res.status}`);
 
-            alert('Mensagem enviada! Retornaremos em breve.');
+            if (successModal) {
+                const firstName = data.name.split(' ')[0];
+                document.getElementById('successModalTitle').textContent = `Obrigado, ${firstName}!`;
+                document.getElementById('successModalMessage').textContent = `Olá ${firstName}, recebemos sua mensagem e em breve entraremos em contato.`;
+                successModal.classList.add('open');
+            } else {
+                alert('Mensagem enviada! Retornaremos em breve.');
+            }
             form.reset();
         } catch (err) {
             console.error('Form submission error:', err);


### PR DESCRIPTION
## Summary
- adiciona marcação e estilos para modal de confirmação de contato
- substitui alerta por pop-up que inclui o nome enviado no formulário

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc35f2fbcc832dbca80478fb33825f